### PR TITLE
feature(Allocation): Refactor allocation system in cartographer, enable updating allocation through ElevationHelper

### DIFF
--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -99,16 +99,15 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     uint256 public devSummitPerSecond;                                          // Amount of Summit minted per second to the treasury
     uint256 public referralsSummitPerSecond;                                    // Amount of Summit minted per second as referral rewards
 
-    uint16[] public poolIds;                                                    // List of all pool identifiers (PIDs)
+    uint16[] public elevationPoolCount;                                         // List of all pool identifiers (PIDs)
 
     mapping(address => address) public tokenPassthroughStrategy;                // Passthrough strategy of each stakable token
 
-    uint256 public totalSharedAlloc = 0;                                        // Total allocation points: sum of all allocation points in all pools.
+    uint256[5] public elevAlloc = [0, 0, 0, 0, 0];                              // Total allocation points of all pools at an elevation
     mapping(address => bool) public tokenAllocExistence;                        // Whether an allocation has been created for a specific token
     mapping(address => uint16) public tokenFee;                                 // Fee for all farms of this token
     address[] tokensWithAllocation;                                             // List of Token Addresses that have been assigned an allocation
-    mapping(address => uint256) public tokenBaseAlloc;                          // A tokens underlying allocation, which is modulated for each elevation
-    mapping(address => uint256) public tokenSharedAlloc;                        // Sum of the tokens modulated allocations across enabled elevations
+    mapping(address => uint256) public tokenAlloc;                              // A tokens underlying allocation, which is modulated for each elevation
 
     mapping(address => mapping(uint8 => bool)) public poolExistence;            // Whether a pool exists for a token at an elevation
     mapping(address => mapping(uint8 => bool)) public tokenElevationIsEarning;  // If a token is earning SUMMIT at a specific elevation
@@ -160,9 +159,6 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         devAdd = _devAdd;
         expedAdd = _expedAdd;
         trustedSeederAdd = _trustedSeederAdd;
-
-        // The first PID is left empty
-        poolIds.push(0);
     }
 
     /// @dev Initialize, simply setting addresses, these contracts need the Cartographer address so it must be separate from the constructor
@@ -357,22 +353,10 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         _;
     }
 
-
-
-
-
-    // ---------------------------------------
-    // --   U T I L S (inlined for brevity)
-    // ---------------------------------------
-
-    /// @dev Total number of pools
-    function poolsCount() external view returns (uint256) {
-        return poolIds.length;
-    }
-
-    /// @dev Timestamp when a round of an elevation ends
-    function roundEndTimestamp(uint8 _elevation) public view isElevation(_elevation) returns(uint256) {
-        return elevationHelper.roundEndTimestamp(_elevation);
+    // Totem
+    modifier validTotem(uint8 _elevation, uint8 _totem)  {
+        require(_totem < elevationHelper.totemCount(_elevation), "Invalid totem");
+        _;
     }
 
 
@@ -420,38 +404,28 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         tokensWithAllocation.push(_token);
 
         // Token's base allocation is set to the passed in value
-        tokenBaseAlloc[_token] = _allocation;
-
-        // Creating an allocation happens before any pools are created, so the shared allocation is 0 at present
-        // No shared allocation needs to be added to the total allocation yet
-        tokenSharedAlloc[_token] = 0;
+        tokenAlloc[_token] = _allocation;
 
         emit TokenAllocCreated(_token, _allocation);
     }
 
-    /// @dev Update the allocation for a token. This modifies existing allocations for that token
+    /// @dev Update the allocation for a token. This modifies existing allocations at each elevation for that token
     /// @param _token Token to update allocation for
     /// @param _allocation Updated allocation
     function setTokenSharedAlloc(address _token, uint256 _allocation)
         public
         onlyOwner tokenAllocExists(_token)  validAllocation(_allocation)
     {
-        // Recalculates the total shared allocation for the token
-        //   Each elevation may already be live, so the shared allocation is the sum of the modulated base allocation at each live elevation
-        uint256 updatedSharedAlloc = _allocation * (
-            (tokenElevationIsEarning[_token][OASIS] ? 100 : 0) +
-            (tokenElevationIsEarning[_token][PLAINS] ? 110 : 0) +
-            (tokenElevationIsEarning[_token][MESA] ? 125 : 0) +
-            (tokenElevationIsEarning[_token][SUMMIT] ? 150 : 0)
-        );
+        // Update the tokens allocation at the elevations that token is active at
+        for (uint8 elevation = OASIS; elevation <= SUMMIT; elevation++) {
+            if (tokenElevationIsEarning[_token][elevation]) {
+                elevAlloc[elevation] = elevAlloc[elevation] + _allocation - tokenAlloc[_token];
+            }
+        }
 
-        // The current shared allocation of the token is removed from the total allocation across all tokens
-        // The new shared allocation is then added back in
-        totalSharedAlloc = totalSharedAlloc - tokenSharedAlloc[_token] + updatedSharedAlloc;
+        // Update the token allocation
+        tokenAlloc[_token] = _allocation;
 
-        // Base and shared allocations are updated
-        tokenSharedAlloc[_token] = updatedSharedAlloc;
-        tokenBaseAlloc[_token] = _allocation;
         emit TokenAllocUpdated(_token, _allocation);
     }
 
@@ -464,14 +438,14 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         external
         onlySubCartographer
     {
-        // Fetches the modulated allocation for this token at elevation
-        uint256 modAllocPoint = elevationHelper.elevationModulatedAllocation(tokenBaseAlloc[_token], _elevation);
+        // Add the new allocation to the token's shared allocation and total allocation
+        if (_isEarning) {
+            elevAlloc[_elevation] += tokenAlloc[_token];
 
-        // Add / Remove the new allocation to the token's shared allocation
-        tokenSharedAlloc[_token] = tokenSharedAlloc[_token] + (_isEarning ? modAllocPoint : 0) - (_isEarning ? 0 : modAllocPoint);
-
-        // Add / Remove the new allocation to the total shared allocation
-        totalSharedAlloc = totalSharedAlloc + (_isEarning ? modAllocPoint : 0) - (_isEarning ? 0 : modAllocPoint);
+        // Remove the existing allocation to the token's shared allocation and total allocation
+        } else {
+            elevAlloc[_elevation] -= tokenAlloc[_token];
+        }
 
         // Mark the pool as earning
         tokenElevationIsEarning[_token][_elevation] = _isEarning;
@@ -662,7 +636,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         if (!tokenElevationIsEarning[_token][_elevation]) { return 0; }
 
         // Fetch the modulated base allocation for the token at elevation
-        return elevationHelper.elevationModulatedAllocation(tokenBaseAlloc[_token], _elevation);
+        return elevationHelper.elevationModulatedAllocation(tokenAlloc[_token], _elevation);
     }
 
 
@@ -710,6 +684,28 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     }
 
 
+    /// @dev Emission multiplier of token based on its allocation
+    /// @return Multiplier raised 1e12
+    function tokenAllocEmissionMultiplier(address _token)
+        internal view
+        returns (uint256)
+    {
+        // Sum allocation of all elevations with allocation multipliers
+        uint256 tokenTotalAlloc = 0;
+        uint256 totalAlloc = 0;
+        for (uint8 elevation = OASIS; elevation <= SUMMIT; elevation++) {
+            if (tokenElevationIsEarning[_token][elevation]) {
+                tokenTotalAlloc += tokenAlloc[_token] * elevationHelper.elevationAllocMultiplier(elevation);
+            }
+            totalAlloc += elevAlloc[elevation] * elevationHelper.elevationAllocMultiplier(elevation);
+        }
+
+        if (totalAlloc == 0) return 0;
+
+        return tokenTotalAlloc * 1e12 / totalAlloc;
+    }
+
+
     /// @dev Uses the tokenElevationEmissionMultiplier along with timeDiff and token allocation to calculate the overall emission multiplier of the pool
     /// @param _lastRewardTimestamp Calculate the difference to determine emission event count
     /// (@param _token, @param elevation) Pool identifier for calculation
@@ -718,14 +714,11 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         internal view
         returns (uint256)
     {
-        // Escape early if no total allocation exists
-        if (totalSharedAlloc == 0) { return 0; }
-
         // Calculate overall emission granted over time span, calculated by:
         //   . Time difference from last reward timestamp
         //   . Tokens allocation as a fraction of total allocation
         //   . Pool's emission multiplier
-        return (((timeDiffSeconds(_lastRewardTimestamp, block.timestamp) * 1e12 * tokenSharedAlloc[_token]) / totalSharedAlloc) * tokenElevationEmissionMultiplier(_token, _elevation)) / 1e12;
+        return timeDiffSeconds(_lastRewardTimestamp, block.timestamp) * tokenAllocEmissionMultiplier(_token) * tokenElevationEmissionMultiplier(_token, _elevation) / 1e12;
     }
 
 
@@ -781,11 +774,8 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     /// @param _crossCompound Whether to cross compound earnings from active pools that would be harvested during this tx
     function switchTotem(uint8 _elevation, uint8 _totem, bool _crossCompound)
         public
-        nonReentrant isElevation(_elevation)
+        nonReentrant isElevation(_elevation) validTotem(_elevation, _totem)
     {
-        // Totem must be less than the totem count of the elevation
-        require(_totem < elevationHelper.totemCount(_elevation), "Invalid totem");
-
         // Executes the totem switch in the correct subcartographer
         subCartographer(_elevation).switchTotem(_totem, msg.sender, _crossCompound);
 


### PR DESCRIPTION
There was a bug in the updating the allocation in V1.

-- ALLOCATION --

This addresses the issue by moving away from a `totalSharedAlloc` and a `tokenSharedAlloc` which kept running allocations for the entire system, and a single token across all elevations. This could become out of sync in specific conditions, and cause problems with emissions and turning on / off farms.

This is fixed by instead keeping only the 'base' allocation of the token in `tokenAlloc`, as well as a running total of an elevations total allocation in `elevAlloc`. When a pool begins or ends earning, and `setTokenIsEarningAtElev` is called, it either adds or removes that token's base allocation from that elevations allocation. This means that the system is completely independent of the actual weighting of each elevation, which used to be baked into the shared allocations.

This has also opened the opportunity to allow the allocations multipliers of each elevation (in ElevationHelper.sol) to be adjustable after deployment. This PR also creates the setters that can change the multipliers of each elevation. In the OASIS the updated allocation takes place immediately, however at other elevations it takes effect at the end of the round.


-- ROUND DURATION -- 

Additionally, I've added a setter for round durations for each elevation (excluding OASIS). This is also in ElevationHelper.sol. These round durations are multipliers against the base round duration, which is set to 3600 seconds (1 hour). The updated value is validated to be non zero (this would be a big problem), and it is set as 'pending' in `pendingDurationMult`, which then gets finalized at the next round rollover. 

This has changed the logic of updated the round end timestamp. Previously it would take the round end timestamp of the most recent round, add the round duration of the upcoming round, as well as any 'overflown rounds' (rounds which ended but were never rolled over - not an issue in practice) to bring it current. This has been broken apart, the overflown rounds are used to bring the timestamp current, and then the newly updated round duration (if updated using the setter above) is used to set the upcoming rounds end timestamp.

