### PR TITLE
feature(decaying withdrawal fee): Refactor fee system in cartographer and cartographerElevation

### DIFF
--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -112,8 +112,8 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     mapping(address => mapping(uint8 => bool)) public poolExistence;            // Whether a pool exists for a token at an elevation
     mapping(address => mapping(uint8 => bool)) public tokenElevationIsEarning;  // If a token is earning SUMMIT at a specific elevation
 
-    uint256 baseMinimumWithdrawalFee = 20;
-    uint256 decayDuration = 10 * 86400;
+    uint16 baseMinimumWithdrawalFee = 20;
+    uint256 feeDecayDuration = 10 * 86400;
 
 
 
@@ -381,18 +381,6 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     // ---------------------------------------
     // --   T O K E N   A L L O C A T I O N
     // ---------------------------------------
-
-
-    /// @dev Set the fee for a token
-    function setTokenFee(address _token, uint16 _feeBP)
-        public
-        onlyOwner
-    {
-        // Fees will never be higher than 5%
-        require(_feeBP <= 500, "Invalid fee");
-        tokenFee[_token] = _feeBP;
-    }
-
 
     /// @dev Create a new base allocation for a token. Required before a pool for that token is created
     /// @param _token Token to create allocation for
@@ -1000,8 +988,8 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         uint16 baseFee = tokenFee[_token];
         uint16 remainingFee = baseMinimumWithdrawalFee;
         uint256 timeDiff = block.timestamp - _lastDepositTimestamp;
-        if (timeDiff < decayDuration) {
-            remainingFee = baseMinimumWithdrawalFee + ((baseFee - baseMinimumWithdrawalFee) * (decayDuration - timeDiff) * 1e12 / decayDuration) / 1e12;
+        if (timeDiff < feeDecayDuration) {
+            remainingFee = baseMinimumWithdrawalFee + ((baseFee - baseMinimumWithdrawalFee) * (feeDecayDuration - timeDiff) * 1e12 / feeDecayDuration) / 1e12;
         }
         uint256 expectedWithdrawnAmount = (_amount * (10000 - remainingFee)) / 10000;
 
@@ -1057,5 +1045,37 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         require(_amount > 0, "Non zero");
 
         summit.mint(address(summitReferrals), _amount);
+    }
+
+    // -----------------------------------------------------
+    // --   Fee management
+    // -----------------------------------------------------
+
+    /// @dev Set the fee for a token
+    function setTokenFee(address _token, uint16 _feeBP)
+        public
+        onlyOwner
+    {
+        // Fees will never be higher than 5%
+        require(_feeBP <= 500, "Invalid fee");
+        tokenFee[_token] = _feeBP;
+    }
+
+    /// @dev Set the fee decaying duration
+    function setFeeDecayDuration(uint256 _feeDecayDuration)
+        public
+        onlyOwner
+    {
+        feeDecayDuration = _feeDecayDuration;
+    }
+
+    /// @dev Set the minimum withdrawal fee
+    function setBaseMinimumWithdrawalFee(uint16 _baseMinimumWithdrawalFee)
+        public
+        onlyOwner
+    {
+        require(_baseMinimumWithdrawalFee < 10, "Invalid minimum fee lower than mimum");
+        require(_baseMinimumWithdrawalFee > 100, "Invalid minimum fee bigger than maximum");
+        baseMinimumWithdrawalFee = _baseMinimumWithdrawalFee;
     }
 }

--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -988,7 +988,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         uint16 baseFee = tokenFee[_token];
         uint16 remainingFee = baseMinimumWithdrawalFee;
         uint256 timeDiff = block.timestamp - _lastDepositTimestamp;
-        if (timeDiff < feeDecayDuration) {
+        if (baseFee > baseMinimumWithdrawalFee && timeDiff < feeDecayDuration) {
             remainingFee = baseMinimumWithdrawalFee + ((baseFee - baseMinimumWithdrawalFee) * (feeDecayDuration - timeDiff) * 1e12 / feeDecayDuration) / 1e12;
         }
         uint256 expectedWithdrawnAmount = (_amount * (10000 - remainingFee)) / 10000;

--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -113,8 +113,8 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     mapping(address => mapping(uint8 => bool)) public tokenElevationIsEarning;  // If a token is earning SUMMIT at a specific elevation
 
     mapping(address => uint256) public lastDepositTimestamps;                   // Users' last deposit timestamp
-    uint16 baseMinimumWithdrawalFee = 20;
-    uint256 feeDecayDuration = 10 * 86400;
+    uint16 public baseMinimumWithdrawalFee = 20;
+    uint256 public feeDecayDuration = 10 * 86400;
 
 
 

--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -1074,8 +1074,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         public
         onlyOwner
     {
-        require(_baseMinimumWithdrawalFee < 10, "Invalid minimum fee lower than mimum");
-        require(_baseMinimumWithdrawalFee > 100, "Invalid minimum fee bigger than maximum");
+        require(_baseMinimumWithdrawalFee >= 10 && _baseMinimumWithdrawalFee <= 100, "Minimum fee outside 1%-10%");
         baseMinimumWithdrawalFee = _baseMinimumWithdrawalFee;
     }
 }

--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -990,7 +990,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         uint16 remainingFee = baseMinimumWithdrawalFee;
         uint256 timeDiff = block.timestamp - lastDepositTimestamps[_userAdd];
         if (baseFee > baseMinimumWithdrawalFee && timeDiff < feeDecayDuration) {
-            remainingFee = baseMinimumWithdrawalFee + ((baseFee - baseMinimumWithdrawalFee) * (feeDecayDuration - timeDiff) * 1e12 / feeDecayDuration) / 1e12;
+            remainingFee = baseMinimumWithdrawalFee + uint16(((baseFee - baseMinimumWithdrawalFee) * (feeDecayDuration - timeDiff) * 1e12 / feeDecayDuration) / 1e12);
         }
         uint256 expectedWithdrawnAmount = (_amount * (10000 - remainingFee)) / 10000;
 

--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -112,6 +112,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     mapping(address => mapping(uint8 => bool)) public poolExistence;            // Whether a pool exists for a token at an elevation
     mapping(address => mapping(uint8 => bool)) public tokenElevationIsEarning;  // If a token is earning SUMMIT at a specific elevation
 
+    mapping(address => uint256) public lastDepositTimestamps;                   // Users' last deposit timestamp
     uint16 baseMinimumWithdrawalFee = 20;
     uint256 feeDecayDuration = 10 * 86400;
 
@@ -798,6 +799,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
                 _crossCompound,
                 false
             );
+        lastDepositTimestamps[msg.sender] = block.timestamp;
 
         emit Deposit(msg.sender, _token, _elevation, amountAfterFee);
     }
@@ -974,9 +976,8 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
     /// @param _userAdd Withdrawing user
     /// @param _token Token to withdraw
     /// @param _amount Withdraw amount
-    /// @param _lastDepositTimestamp Last deposit timestamp
     /// @return Amount withdrawn after fee
-    function withdrawalTokenManagement(address _userAdd, address _token, uint256 _amount, uint256 _lastDepositTimestamp)
+    function withdrawalTokenManagement(address _userAdd, address _token, uint256 _amount)
         external
         onlySubCartographer
         returns (uint256)
@@ -987,7 +988,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         // Amount user expects to receive after fee taken
         uint16 baseFee = tokenFee[_token];
         uint16 remainingFee = baseMinimumWithdrawalFee;
-        uint256 timeDiff = block.timestamp - _lastDepositTimestamp;
+        uint256 timeDiff = block.timestamp - lastDepositTimestamps[_userAdd];
         if (baseFee > baseMinimumWithdrawalFee && timeDiff < feeDecayDuration) {
             remainingFee = baseMinimumWithdrawalFee + ((baseFee - baseMinimumWithdrawalFee) * (feeDecayDuration - timeDiff) * 1e12 / feeDecayDuration) / 1e12;
         }

--- a/contracts/CartographerElevation.sol
+++ b/contracts/CartographerElevation.sol
@@ -126,6 +126,7 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
         uint256 roundRew;                           // Running sum of user's rewards earned in current round
 
         uint256 winningsDebt;                       // AccWinnings of user's totem at time of deposit
+        uint256 lastDepositTimestamp;               // Last timestamp user deposits fund into pool
 
         // ReVesting                                // When a user interacts with a round where some funds are already vesting, the remaining amount to vest is re-vested here
         uint256 reVestAmt;                          // The amount of SUMMIT reward to vest over a duration
@@ -1372,6 +1373,7 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
         internal
         returns (uint256)
     {
+        user.lastDepositTimestamp = block.timestamp;
         updatePool(pool.token);
         uint8 totem = _getUserTotem(_userAdd);
 
@@ -1437,7 +1439,7 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
         // Elevated funds remain in the cartographer, or in the passthrough target, so no need to withdraw from anywhere as they would be immediately re-deposited
         uint256 amountAfterFee = amount;
         if (!_isInternalTransfer) {
-            amountAfterFee = cartographer.withdrawalTokenManagement(_userAdd, pool.token, amount);
+            amountAfterFee = cartographer.withdrawalTokenManagement(_userAdd, pool.token, amount, user.lastDepositTimestamp);
         }
 
         // Remove withdrawn amount from pool's running supply accumulators

--- a/contracts/CartographerElevation.sol
+++ b/contracts/CartographerElevation.sol
@@ -126,7 +126,6 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
         uint256 roundRew;                           // Running sum of user's rewards earned in current round
 
         uint256 winningsDebt;                       // AccWinnings of user's totem at time of deposit
-        uint256 lastDepositTimestamp;               // Last timestamp user deposits fund into pool
 
         // ReVesting                                // When a user interacts with a round where some funds are already vesting, the remaining amount to vest is re-vested here
         uint256 reVestAmt;                          // The amount of SUMMIT reward to vest over a duration
@@ -1373,7 +1372,6 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
         internal
         returns (uint256)
     {
-        user.lastDepositTimestamp = block.timestamp;
         updatePool(pool.token);
         uint8 totem = _getUserTotem(_userAdd);
 
@@ -1439,7 +1437,7 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
         // Elevated funds remain in the cartographer, or in the passthrough target, so no need to withdraw from anywhere as they would be immediately re-deposited
         uint256 amountAfterFee = amount;
         if (!_isInternalTransfer) {
-            amountAfterFee = cartographer.withdrawalTokenManagement(_userAdd, pool.token, amount, user.lastDepositTimestamp);
+            amountAfterFee = cartographer.withdrawalTokenManagement(_userAdd, pool.token, amount);
         }
 
         // Remove withdrawn amount from pool's running supply accumulators


### PR DESCRIPTION
Decaying Withdrawal Fees

Existing Implementation: An Overall fee is set anywhere from 0% - 4% for each token. This is set separately of the farms so that it can be shared across all elevations. This fee is split into a Deposit fee and a Withdrawal fee:
  . The Deposit fee is Max(0, Overall fee - 0.5%)
  . The Withdrawal fee is Min(0.5, Overall fee)

Proposal: Fees are replaced with a 'decaying' fee on Withdrawal. This fee decays (reduces) every second over 10 days from the point of the user's most recent deposit from the total fee amount to 0.2%. EX: A user deposits on Day 0, their fee is 4%, on Day 5 their fee is (4% - 0.2%) * (5 / 10) = 1.9%. If that user deposits again on Day 5, their fee is reset to 4% and begins decaying again.

Example fee:
  for i.e, overal fee: 2.2%, decaying duration: 10 days
    . day0: (2.2%-0.2%) * (10-0)/ + 0.2%  = 2.2%
    . day1: (2.2%-0.2%) * (10-1)/10 + 0.2%  = 2.0%
    . day2: (2.2%-0.2%) * (10-2)/10 + 0.2%  = 1.8%
    . day9: (2.2%-0.2%) * (10-9)/10 + 0.2%  = 0.4%
    . day10:(2.2%-0.2%) * (10-10)/10 + 0.2% = 0.2%

Important notes:
  . Withdrawal fee decay rate should be adjustable (10 days --> 5 days for example). This updates instantly and doesn't need to grandfather in users that already have fees.
  . Each token should have its own fee
  . Each token's fee should be adjustable, anywhere from 5% to 0%. This updates instantly.
  . Fees are raised to the power of 1e4, so a fee of 5% is 500, and a fee of 0.1% is 10.
  . The max fee is 500 (5%)
  . A token with a fee < 20 (0.2%) doesn't decay at all
  . Minimum deposit fee is 0.2% (20) and should be adjustable. (Adjustable min value = 10 (0.1%), max value = 100 (1%))

Variable Names:
  . feeDecayDuration = 10 (initial)