### PR TITLE
fix(AuditPhase3) - Fixes to contract to solve Phase 3 audit problems

### DIFF
--- a/contracts/Cartographer.sol
+++ b/contracts/Cartographer.sol
@@ -443,6 +443,9 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
         external
         onlySubCartographer
     {
+        // Early escape if token earning is already up to date
+        if (tokenElevationIsEarning[_token][_elevation] == _isEarning) return;
+
         // Add the new allocation to the token's shared allocation and total allocation
         if (_isEarning) {
             elevAlloc[_elevation] += tokenAlloc[_token];
@@ -452,7 +455,7 @@ contract Cartographer is Ownable, Initializable, ReentrancyGuard {
             elevAlloc[_elevation] -= tokenAlloc[_token];
         }
 
-        // Mark the pool as earning
+        // Mark the token-elevation earning
         tokenElevationIsEarning[_token][_elevation] = _isEarning;
     }
 

--- a/contracts/CartographerElevation.sol
+++ b/contracts/CartographerElevation.sol
@@ -539,7 +539,7 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
         if (!userElevationInfo[_userAdd].totemSelected) return (0, 0);
         uint8 userTotem = userElevationInfo[_userAdd].totem;
 
-        // Iterate through active pools of elevation, sum total rewards earned (all totems), and winning totems's rewards
+        // Iterate through active pools of elevation, sums {users yield contributed, total rewards earned (all totems), and winning totems's rewards}
         uint256 userTotalYieldContributed = 0;
         uint256 elevTotalRewards = 0;
         uint256 userTotemTotalWinnings = 0;
@@ -555,7 +555,7 @@ contract CartographerElevation is ISubCart, Ownable, Initializable, ReentrancyGu
             userTotemTotalWinnings += poolUserTotemWinnings;
         }
 
-        // Calculate the winnings multiplier of the round that just ended from the combined reward amounts
+        // Calculate the winnings multiplier of the users totem (assuming it wins)
         uint256 elevWinningsMult = userTotemTotalWinnings == 0 ? 0 : elevTotalRewards * 1e12 / userTotemTotalWinnings;
 
         return (

--- a/contracts/CartographerOasis.sol
+++ b/contracts/CartographerOasis.sol
@@ -338,7 +338,6 @@ contract CartographerOasis is ISubCart, Ownable, Initializable, ReentrancyGuard 
     // ------------------------------------------------------------------
     
 
-    function hypotheticalRewards(address, address) public pure returns (uint256, uint256) { return (uint256(0), 0); }
     function rollover() external override {}
     function switchTotem(uint8, address) external override {}
 

--- a/contracts/CartographerOasis.sol
+++ b/contracts/CartographerOasis.sol
@@ -183,18 +183,6 @@ contract CartographerOasis is ISubCart, Ownable, Initializable, ReentrancyGuard 
     // ---------------------------------------
 
 
-    /// @dev Registers pool everywhere needed
-    /// @param _token Token to register with
-    /// @param _live Whether pool is enabled at time of creation
-    function registerPool(address _token, bool _live) internal {
-        // Marks token as enabled at elevation, and adds token allocation to token's shared allocation and total allocation
-        if (_live) cartographer.setIsTokenEarningAtElevation(_token, OASIS, true);
-
-        // Add token to poolTokens
-        poolTokens.add(_token);
-    }
-
-
     /// @dev Creates a pool at the oasis
     /// @param _token Pool token
     /// @param _live Whether the pool is enabled initially
@@ -202,8 +190,8 @@ contract CartographerOasis is ISubCart, Ownable, Initializable, ReentrancyGuard 
         external override
         onlyCartographer nonDuplicated(_token)
     {
-        // Register pid and token where needed
-        registerPool(_token, _live);
+        // Add token to poolTokens
+        poolTokens.add(_token);
 
         // Create the initial state of the pool
         poolInfo[_token] = OasisPoolInfo({
@@ -227,11 +215,26 @@ contract CartographerOasis is ISubCart, Ownable, Initializable, ReentrancyGuard 
         OasisPoolInfo storage pool = poolInfo[_token];
         updatePool(_token);
 
-        // If live status of pool changes, update cartographer allocations
-        if (pool.live != _live) cartographer.setIsTokenEarningAtElevation(pool.token, OASIS, _live);
+        // Update IsEarning in Cartographer
+        _updateTokenIsEarning(pool);
 
         // Update internal pool states
         pool.live = _live;
+    }
+
+
+    /// @dev Mark whether this token is earning at this elevation in the Cartographer
+    ///   Live must be true
+    ///   Launched must be true
+    ///   Staked supply must be non zero
+    function _updateTokenIsEarning(OasisPoolInfo storage pool)
+        internal
+    {
+        cartographer.setIsTokenEarningAtElevation(
+            pool.token,
+            OASIS,
+            pool.live && pool.supply > 0
+        );
     }
 
 
@@ -517,6 +520,9 @@ contract CartographerOasis is ISubCart, Ownable, Initializable, ReentrancyGuard 
             
             // Increment running pool supply with amount after fee taken
             pool.supply += amountAfterFee;
+
+            // Update IsEarning in Cartographer
+            _updateTokenIsEarning(pool);
         }
         
         // Update user info with new staked value, and calculate new debt
@@ -559,6 +565,9 @@ contract CartographerOasis is ISubCart, Ownable, Initializable, ReentrancyGuard 
 
         // Update pool running supply total with amount withdrawn
         pool.supply -= _amount;
+
+        // Update IsEarning in Cartographer
+        _updateTokenIsEarning(pool);
 
         // Update user's staked and debt     
         user.staked -= _amount;

--- a/contracts/ElevationHelper.sol
+++ b/contracts/ElevationHelper.sol
@@ -1,10 +1,10 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.0;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "hardhat/console.sol";
-
 import "./interfaces/ISummitRNGModule.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 
 
 /*
@@ -431,35 +431,22 @@ contract ElevationHelper is Ownable {
     /// @dev Fetcher of historical data for past winning totems
     /// @param _elevation Which elevation to check historical winners of
     /// @return Array of 20 values, first 10 of which are win count accumulators for each totem, last 10 of which are winners of previous 10 rounds of play
-    function historicalWinningTotems(uint8 _elevation) public view allElevations(_elevation) returns (uint256[20] memory) {
-
-        // Early escape OASIS winners, as they don't exist
-        if (_elevation == OASIS) {
-            return [uint256(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        }
+    function historicalWinningTotems(uint8 _elevation) public view allElevations(_elevation) returns (uint256[] memory, uint256[] memory) {
 
         uint256 round = roundNumber[_elevation];
-        return [
-            totemWinsAccum[_elevation][0],
-            totemWinsAccum[_elevation][1],
-            totemWinsAccum[_elevation][2],
-            totemWinsAccum[_elevation][3],
-            totemWinsAccum[_elevation][4],
-            totemWinsAccum[_elevation][5],
-            totemWinsAccum[_elevation][6],
-            totemWinsAccum[_elevation][7],
-            totemWinsAccum[_elevation][8],
-            totemWinsAccum[_elevation][9],
-            winningTotem[_elevation][round - 1],
-            winningTotem[_elevation][round - 2],
-            winningTotem[_elevation][round - 3],
-            winningTotem[_elevation][round - 4],
-            winningTotem[_elevation][round - 5],
-            winningTotem[_elevation][round - 6],
-            winningTotem[_elevation][round - 7],
-            winningTotem[_elevation][round - 8],
-            winningTotem[_elevation][round - 9],
-            winningTotem[_elevation][round - 10]
-        ];
+        uint256 winHistoryDepth = Math.min(10, round);
+
+        uint256[] memory winsAccum = new uint256[](totemCount[_elevation]);
+        uint256[] memory prevWinHistory = new uint256[](winHistoryDepth);
+
+        if (_elevation > OASIS) {
+            uint256 prevRound = round == 0 ? 0 : round - 1;
+            for (uint8 i = 0; i < totemCount[_elevation]; i++) {
+                winsAccum[i] = totemWinsAccum[_elevation][i];
+            }
+            for (uint8 j = 0; j < winHistoryDepth; j++) {
+                prevWinHistory[j] = winningTotem[_elevation][prevRound - j];
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes:

1. Issue: `CartographerElevation.sol` Emergency Withdraw has too many dependencies. Fix: In previous commits (updatePool only runs for non-emergency withdrawals)
2. Issue: `CartographerElevation.sol` first interacted round winnings were doubled in rewards calculations. Fix: the user's winningsDebt is offset by 1 round (using the `precomputedMult` of that round) to exclude the first round winnings from the `runningPrecomputedMult` calculation: `CartographerElevation.sol:815`
3. Issue: `CartographerElevation.sol` Protocal values should be public. Fix: In previous commits (made variables public and added EnumerableSet getters)
4. Issue: Returning static length arrays. Fix: Populate and return dynamic length arrays
5. Issue: `CartographerElevation.sol` Redundant active check for `markPoolsActive`. Fix: `markPoolActive` is not put behind any pool.active conditionals and is run more consistently.
6. Issue: `CartographerElevation.sol` Rewards calculation does not match rollover. Fix: Break into two functions, first returns only the contributed yield of the user for a specific pool, 2nd returns the potential winnings of the user across the entire elevation by mirroring the roundRollover summation calculations


Additional Fixes:
setTokenIsEarningAtElevation is called more regularly, and includes the pool.supply being non-zero into its calculation. This fixes a potential bug where a pools emissions calculation is taking into account a pool that shouldn't be earning rewards, but is marked as earning. This fix also adds an early exit to the cartographer function if the pool's `isEarning` is already up to date.
  