### PR TITLE
fix(AuditPhase4): Fixes from the audit phase 4 Results

### DIFF
--- a/contracts/BaseEverestExtension.sol
+++ b/contracts/BaseEverestExtension.sol
@@ -13,7 +13,7 @@ abstract contract BaseEverestExtension {
         _;
     }
 
-    function getUserEverest(address _userAdd)
+    function _getUserEverest(address _userAdd)
         internal view
         returns (uint256)
     {

--- a/contracts/EverestToken.sol
+++ b/contracts/EverestToken.sol
@@ -26,9 +26,10 @@ contract EverestToken is ERC20('EverestToken', 'EVEREST'), Ownable, ReentrancyGu
 
     bool public panic = false;
 
-    uint256 public minLockTime = 3600 * 24 * 7;
-    uint256 public inflectionLockTime = 3600 * 24 * 30;
-    uint256 public maxLockTime = 3600 * 24 * 365;
+    uint256 public daySeconds = 24 * 3600;
+    uint256 public minLockTime = 7 days;
+    uint256 public inflectionLockTime = 30 days;
+    uint256 public maxLockTime = 365 days;
     uint256 public minEverestLockMult = 1000;
     uint256 public inflectionEverestLockMult = 10000;
     uint256 public maxEverestLockMult = 25000;
@@ -137,17 +138,17 @@ contract EverestToken is ERC20('EverestToken', 'EVEREST'), Ownable, ReentrancyGu
 
     function setMinLockTime(uint256 _lockTimeDays) public onlyOwner {
         require(_lockTimeDays <= maxLockTime && _lockTimeDays >= 1 && _lockTimeDays <= 30, "Invalid minimum lock time (1-30 days)");
-        minLockTime = _lockTimeDays * 24 * 365;
+        minLockTime = _lockTimeDays * daySeconds;
         emit SetMinLockTime(_lockTimeDays);
     }
     function setInflectionLockTime(uint256 _lockTimeDays) public onlyOwner {
         require(_lockTimeDays >= minLockTime && _lockTimeDays <= maxLockTime && _lockTimeDays >= 7 && _lockTimeDays <= 365, "Invalid inflection lock time (7-365 days)");
-        minLockTime = _lockTimeDays * 24 * 365;
+        minLockTime = _lockTimeDays * daySeconds;
         emit SetInflectionLockTime(_lockTimeDays);
     }
     function setMaxLockTime(uint256 _lockTimeDays) public onlyOwner {
         require(_lockTimeDays >= minLockTime && _lockTimeDays >= 7 && _lockTimeDays <= 730, "Invalid maximum lock time (7-730 days)");
-        maxLockTime = _lockTimeDays * 24 * 365;
+        maxLockTime = _lockTimeDays * daySeconds;
         emit SetMaxLockTime(_lockTimeDays);
     }
     function setMinEverestLockMult(uint256 _lockMult) public onlyOwner {

--- a/contracts/EverestToken.sol
+++ b/contracts/EverestToken.sol
@@ -113,13 +113,6 @@ contract EverestToken is ERC20('EverestToken', 'EVEREST'), Ownable, ReentrancyGu
         require (_everestAmount > 0 && _everestAmount <= userEverestInfo[msg.sender].everestOwned, "Bad withdraw");
         _;
     }
-    function _validUserAdd(address _userAdd) internal pure {
-        require(_userAdd != address(0), "User address is zero");
-    }
-    modifier validUserAdd(address _userAdd) {
-        _validUserAdd(_userAdd);
-        _;
-    }
     modifier onlyPanic() {
         require(panic, "Not in panic");
         _;

--- a/contracts/ExpeditionV2.sol
+++ b/contracts/ExpeditionV2.sol
@@ -173,6 +173,7 @@ contract ExpeditionV2 is Ownable, Initializable, ReentrancyGuard, BaseEverestExt
     event UserHarvestedExpedition(address indexed user, uint256 _summitHarvested, uint256 _usdcHarvested);
 
     event ExpeditionInitialized(address _usdcTokenAddress, address _elevationHelper);
+    event ExpeditionEmissionsRecalculated(uint256 _roundsRemaining, uint256 _summitEmissionPerRound, uint256 _usdcEmissionPerRound);
     event ExpeditionFundsAdded(address indexed token, uint256 _amount);
     event ExpeditionDisabled();
     event ExpeditionEnabled();
@@ -372,6 +373,12 @@ contract ExpeditionV2 is Ownable, Initializable, ReentrancyGuard, BaseEverestExt
         bool summitFundNonZero = _recalculateExpeditionTokenEmissions(expeditionInfo.summit);
         bool usdcFundNonZero = _recalculateExpeditionTokenEmissions(expeditionInfo.usdc);
         expeditionInfo.roundsRemaining = (summitFundNonZero || usdcFundNonZero) ? expeditionRunwayRounds : 0;
+    }
+    function recalculateExpeditionEmissions()
+        public onlyOwner
+    {
+        _recalculateExpeditionEmissions();
+        emit ExpeditionEmissionsRecalculated(expeditionInfo.roundsRemaining, expeditionInfo.summit.roundEmission, expeditionInfo.usdc.roundEmission);
     }
 
     /// @dev Add funds to the expedition
@@ -658,9 +665,29 @@ contract ExpeditionV2 is Ownable, Initializable, ReentrancyGuard, BaseEverestExt
     // ---------------------------------------
 
 
+    function syncEverestAmount()
+        public
+        nonReentrant
+    {
+        _updateUserEverestAmount(
+            msg.sender,
+            _getUserEverest(msg.sender)
+        );
+    }
+
+
     function updateUserEverest(uint256 _everestAmount, address _userAdd)
         external override
         onlyEverestToken
+    {
+        _updateUserEverestAmount(
+            _userAdd,
+            _everestAmount
+        );
+    }
+
+    function _updateUserEverestAmount(address _userAdd, uint256 _everestAmount)
+        internal
     {
         UserExpeditionInfo storage user = _getOrCreateUserInfo(_userAdd);
 
@@ -777,7 +804,7 @@ contract ExpeditionV2 is Ownable, Initializable, ReentrancyGuard, BaseEverestExt
             userExpeditionInfo[_userAdd].deitySelected,
             userExpeditionInfo[_userAdd].safetyFactorSelected
         );
-    }    
+    }
 
     function joinExpedition()
         public

--- a/contracts/ExpeditionV2.sol
+++ b/contracts/ExpeditionV2.sol
@@ -269,10 +269,6 @@ contract ExpeditionV2 is Ownable, Initializable, ReentrancyGuard, BaseEverestExt
         require(userExpeditionInfo[msg.sender].safetyFactorSelected, "No safety factor selected");
         _;
     }
-    modifier elevationHelperRoundRolledOver() {
-        require(elevationHelper.roundNumber(EXPEDITION) > rolledOverRounds, "Elev helper must be rolled over first");
-        _;
-    }
     
 
 
@@ -332,7 +328,7 @@ contract ExpeditionV2 is Ownable, Initializable, ReentrancyGuard, BaseEverestExt
 
     
     function setExpeditionDeityWinningsMult(uint256 _deityMult) public onlyOwner {
-        require(_deityMult >= 100 && _deityMult <= 500, "Invalid runway rounds (7-90)");
+        require(_deityMult >= 100 && _deityMult <= 500, "Invalid deity mult (1X-5X)");
         expeditionDeityWinningsMult = _deityMult;
         emit SetExpeditionDeityWinningsMult(_deityMult);
     }

--- a/contracts/dummy/DummyEverestExtension.sol
+++ b/contracts/dummy/DummyEverestExtension.sol
@@ -19,7 +19,7 @@ contract DummyEverestExtension is BaseEverestExtension {
     function joinDummyExtension()
         public
     {
-        userEverest[msg.sender] = getUserEverest(msg.sender);
+        userEverest[msg.sender] = _getUserEverest(msg.sender);
     }
 
     function updateUserEverest(uint256 _everestAmount, address _userAdd)

--- a/test/01b-expedition.ts
+++ b/test/01b-expedition.ts
@@ -56,6 +56,7 @@ describe("EXPEDITION V2", async function() {
             tokenAddress: cakeToken.address,
             amount: e18(500),
         })
+        await expeditionMethod.recalculateExpeditionEmissions({ dev })
 
         const expectedEmissionsMid = await expeditionSynth.getExpeditionExpectedEmissions()
         const expeditionInfoMid = await expeditionGet.expeditionInfo()
@@ -72,6 +73,7 @@ describe("EXPEDITION V2", async function() {
             tokenAddress: summitToken.address,
             amount: e18(300),
         })
+        await expeditionMethod.recalculateExpeditionEmissions({ dev })
 
         const expectedEmissionsFinal = await expeditionSynth.getExpeditionExpectedEmissions()
         const expeditionInfoFinal = await expeditionGet.expeditionInfo()
@@ -81,6 +83,27 @@ describe("EXPEDITION V2", async function() {
         expect(expeditionInfoFinal.summitExpeditionToken.roundEmission).to.equal(expectedEmissionsFinal.summitEmission)
         expect(expeditionInfoFinal.usdcExpeditionToken.emissionsRemaining).to.equal(e18(500))
         expect(expeditionInfoFinal.usdcExpeditionToken.roundEmission).to.equal(expectedEmissionsFinal.usdcEmission)
+    })
+
+    it('SYNC EVEREST: Sync everest keeps values correct', async function() {
+        const { user1 } = await getNamedSigners(hre)
+
+        const expeditionInfoInit = await expeditionGet.expeditionInfo()
+        const userExpedInfoInit = await expeditionGet.userExpeditionInfo(user1.address)
+
+        await expeditionMethod.syncEverestAmount({
+            user: user1
+        })
+
+        const expeditionInfoFinal = await expeditionGet.expeditionInfo()
+        const userExpedInfoFinal = await expeditionGet.userExpeditionInfo(user1.address)
+
+        expect(expeditionInfoInit.deitiedSupply).to.equal(expeditionInfoFinal.deitiedSupply)
+        expect(expeditionInfoInit.deitySupply[userExpedInfoInit.deity]).to.equal(expeditionInfoFinal.deitySupply[userExpedInfoInit.deity])
+        expect(expeditionInfoInit.safeSupply).to.equal(expeditionInfoFinal.safeSupply)
+        expect(userExpedInfoInit.everestOwned).to.equal(userExpedInfoFinal.everestOwned)
+        expect(userExpedInfoInit.safeSupply).to.equal(userExpedInfoFinal.safeSupply)
+        expect(userExpedInfoInit.deitiedSupply).to.equal(userExpedInfoFinal.deitiedSupply)
     })
 
     it('EXPEDITION: Users can only enter expedition if they own everest, have selected a deity, and have selected a safety factor', async function() {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -288,6 +288,7 @@ export const EVENT = {
         UserHarvestedExpedition: 'UserHarvestedExpedition',
 
         ExpeditionInitialized: 'ExpeditionInitialized',
+        ExpeditionEmissionsRecalculated: 'ExpeditionEmissionsRecalculated',
         ExpeditionFundsAdded: 'ExpeditionFundsAdded',
         ExpeditionDisabled: 'ExpeditionDisabled',
         ExpeditionEnabled: 'ExpeditionEnabled',

--- a/utils/expeditionUtils.ts
+++ b/utils/expeditionUtils.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "@ethersproject/bignumber"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signers"
 import { expect } from "chai"
 import { string } from "hardhat/internal/core/params/argumentTypes"
-import { consoleLog, e0, e18, elevationHelperGet, EVENT, executeTxExpectEvent, executeTxExpectReversion, EXPEDITION, getElevationHelper, getExpedition, getSummitBalance, getUsdcBalance, mineBlockWithTimestamp, toDecimal, usersExpeditionInfos } from "."
+import { consoleLog, e0, e18, elevationHelperGet, EVENT, executeTx, executeTxExpectEvent, executeTxExpectReversion, EXPEDITION, getElevationHelper, getExpedition, getSummitBalance, getUsdcBalance, mineBlockWithTimestamp, toDecimal, usersExpeditionInfos } from "."
 import { everestGet } from "./everestUtils"
 
 
@@ -177,6 +177,23 @@ export const expeditionMethod = {
             await executeTxExpectEvent(tx, txArgs, expedition, EVENT.Expedition.ExpeditionFundsAdded, eventArgs, true)
         }
     },
+    recalculateExpeditionEmissions: async ({
+        dev,
+        revertErr,
+    }: {
+        dev: SignerWithAddress
+        revertErr?: string,
+    }) => {
+        const expedition = await getExpedition()
+        const tx = expedition.connect(dev).recalculateExpeditionEmissions
+        const txArgs = [] as any[]
+        
+        if (revertErr != null) {
+            await executeTxExpectReversion(tx, txArgs, revertErr)
+        } else {
+            await executeTxExpectEvent(tx, txArgs, expedition, EVENT.Expedition.ExpeditionEmissionsRecalculated, null, true)
+        }
+    },
     disableExpedition: async ({
         user,
         revertErr,
@@ -226,6 +243,23 @@ export const expeditionMethod = {
             await executeTxExpectReversion(tx, txArgs, revertErr)
         } else {
             await executeTxExpectEvent(tx, txArgs, expedition, EVENT.Expedition.Rollover, null, false)
+        }
+    },
+    syncEverestAmount: async ({
+        user,
+        revertErr,
+    }: {
+        user: SignerWithAddress,
+        revertErr?: string
+    }) => {
+        const expedition = await getExpedition()
+        const tx = expedition.connect(user).syncEverestAmount
+        const txArgs = [] as any[]
+        
+        if (revertErr != null) {
+            await executeTxExpectReversion(tx, txArgs, revertErr)
+        } else {
+            await executeTx(tx, txArgs)
         }
     },
     selectDeity: async ({


### PR DESCRIPTION
Fixes:
    . Update EverestToken lock durations to be more readable
    . Update EverestToken lock duration setters with correct multipliers
    . Break apart `addUserFunds` and `recalculateExpeditionEmissions` (and add event) in ExpeditionV2
    . Add `syncEverestAmount` to ExpeditionV2 in case it needs to be swapped over so that users can update with their current everest owned amount
    . Remove unused functions / variables from EverestToken and ExpeditionV2
    . Fix the require fail message of `setExpeditionDeityWinningsMult` in ExpeditionV2